### PR TITLE
Feat : #24 보스레이드 정보 캐싱

### DIFF
--- a/boss_raid/utils.py
+++ b/boss_raid/utils.py
@@ -1,9 +1,63 @@
 import datetime
+import os
 import random
 
+import django
+import requests
+from django.core.cache import cache
 from django.utils import timezone
 
 from .models import BossRaid, RaidRecord
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+
+"""
+Assignee : 정석
+
+redis를 이용한 보스레이드 정보 캐싱 로직입니다.
+보스레이드의 시간만 리턴해주는 get_raid_time
+보스레이드들을 리턴해주는 get_levels 로 구성되어있습니다.
+
+캐싱된 데이터를 필요로하는 이후 로직에서는 2개의 get함수만 사용하게되며,
+캐싱데이터가 없을시엔 자체적으로 get 함수 내에서 create함수를 호출해 캐싱데이터를 생성 후 리턴해줍니다.
+"""
+
+
+def initial_data():
+    url = "https://dmpilf5svl7rv.cloudfront.net/assignment/backend/bossRaidData.json"
+    request = requests.get(url)
+    data = request.json()
+    return data
+
+
+def create_raid_time():
+    data = initial_data()
+    bossraidlimitseconds = data["bossRaids"][0]["bossRaidLimitSeconds"]
+    time = cache.set("limit_time", bossraidlimitseconds, 3600)
+    return time
+
+
+def create_levels():
+    data = initial_data()
+    levels = data["bossRaids"][0]["levels"]
+    levels = cache.set("levels", levels, 3600)
+    return levels
+
+
+def get_raid_time():
+    time = cache.get("limit_time")
+    if time is None:
+        time = create_raid_time()
+    return time
+
+
+def get_levels():
+    levels = cache.get("levels")
+    if levels is None:
+        levels = create_levels()
+    return levels
 
 
 def get_score_and_end_time(record):


### PR DESCRIPTION
### Types of changes

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [ ] 리팩토링

### Summary

- redis를 이용하여 보스레이드 정보를 캐싱합니다.

### Changes

- boss_raid/utils.py


### 특이사항 (Optional)

- 시간만 밸류로 얻는 get_raid_time 함수와
- level정보를 리스트로 받는 get_levels를 추후 로직(view)에서 사용하게끔 구성했습니다.
- 최초데이터 호출, 캐싱데이터 생성은 get함수들에서 돌아가게끔 구성해봤습니다.
- cache.py등의 새로운 파일에 작성하려고 했으나 복잡함을 줄이고자 utils.py에 작성했습니다.
- 캐싱데이터의 유호기간은 3600초(1시간)으로 설정해두었습니다.

### Screenshots (Optional)
