### PR TITLE
Refactor : #37 로그인시 토큰 같이 발급 받는 기능 추가

### DIFF
--- a/boss_raid/views.py
+++ b/boss_raid/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import get_object_or_404
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -40,6 +41,8 @@ class BossRaidEnterAPIView(APIView):
 
     보스레이드 시작 api view 입니다.
     """
+
+    permission_classes = [IsAuthenticated]
 
     def post(self, request):
         """

--- a/user/views.py
+++ b/user/views.py
@@ -40,7 +40,9 @@ class UserSigninApiView(APIView):
     """
     Assignee : 훈희
 
-    로그인과 회원 전체 조회, 회원 단건 조회 기능입니다.
+    post : 로그인
+
+    get : 회원 단건 조회 기능입니다.
     로그인시 입력 data 타입 json 구조는 밑과 같습니다.
     {
         "nickname" : "test1",
@@ -50,7 +52,6 @@ class UserSigninApiView(APIView):
     """
 
     permission_classes = [AllowAny]
-    user_serializer = UserSigninSerializer
 
     def post(self, request):
         nickname = request.data.get("nickname", "")
@@ -60,8 +61,23 @@ class UserSigninApiView(APIView):
         if not user:
             return Response({"error": "존재하지 않는 계정이거나 패스워드가 일치하지 않습니다."}, status=status.HTTP_401_UNAUTHORIZED)
 
+        user_serializer = UserSigninSerializer(user)
+        token = GameTokenObtainPairSerializer.get_token(user)
+        refresh_token = str(token)
+        access_token = str(token.access_token)
+        response = Response(
+            {
+                "user": user_serializer.data,
+                "message": "로그인 성공!!",
+                "token": {
+                    "access": access_token,
+                    "refresh": refresh_token,
+                },
+            },
+            status=status.HTTP_200_OK,
+        )
         login(request, user)
-        return Response({"message": "로그인 성공!!"}, status=status.HTTP_200_OK)
+        return response
 
     def delete(self, request):
         user = request.user


### PR DESCRIPTION
- 로그인 기능을 수행하면 토큰을 함께 전달
- 사용된 GameTokenObtainPairSerializer은 custom된 내용으로
payload data에 닉네임과 id를 담고 있음

### Types of changes

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [x] 리팩토링

### Summary

- 로그인시 토큰을 같이 전달받게 리팩토링


### Screenshots (Optional)
![image](https://user-images.githubusercontent.com/89897944/179023628-b0d39256-6b43-4c81-b1d3-1f8d5e0bd7a6.png)

