### PR TITLE
Feature/#37 로그아웃 기능 리팩토링 - 토큰 같이 반납할 수 있게 변경

### DIFF
--- a/boss_raid/views.py
+++ b/boss_raid/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import get_object_or_404
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -40,6 +41,8 @@ class BossRaidEnterAPIView(APIView):
 
     보스레이드 시작 api view 입니다.
     """
+
+    permission_classes = [IsAuthenticated]
 
     def post(self, request):
         """

--- a/config/settings.py
+++ b/config/settings.py
@@ -35,7 +35,7 @@ DJANGO_APPS = [
     "django.contrib.staticfiles",
 ]
 
-THIRD_PARTY_APPS = ["rest_framework", "rest_framework_simplejwt"]
+THIRD_PARTY_APPS = ["rest_framework", "rest_framework_simplejwt", "rest_framework_simplejwt.token_blacklist"]
 
 PROJECT_APPS = [
     "user",

--- a/user/jwt_claim_serializer.py
+++ b/user/jwt_claim_serializer.py
@@ -1,4 +1,7 @@
+from django.utils.text import gettext_lazy as _
+from rest_framework import serializers
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from rest_framework_simplejwt.tokens import RefreshToken, TokenError
 
 
 class GameTokenObtainPairSerializer(TokenObtainPairSerializer):
@@ -19,3 +22,19 @@ class GameTokenObtainPairSerializer(TokenObtainPairSerializer):
         token["nickname"] = user.nickname
 
         return token
+
+
+class RefreshTokenSerializer(serializers.Serializer):
+    refresh = serializers.CharField()
+
+    default_error_messages = {"bad_token": _("Token is invalid or expired")}
+
+    def validate(self, attrs):
+        self.token = attrs["refresh"]
+        return attrs
+
+    def save(self, **kwargs):
+        try:
+            RefreshToken(self.token).blacklist()
+        except TokenError:
+            self.fail("bad_token")

--- a/user/urls.py
+++ b/user/urls.py
@@ -1,13 +1,21 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
-from .views import GameTokenObtainPairView, UserListAPIView, UserListDetailAPIView, UserSigninApiView, UserSignupApiView
+from .views import (
+    GameTokenObtainPairView,
+    LoginView,
+    LogoutView,
+    UserListAPIView,
+    UserListDetailAPIView,
+    UserSignupApiView,
+)
 
 urlpatterns = [
     path("api/token", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh", TokenRefreshView.as_view(), name="token_refresh"),
     path("api/gametoken", GameTokenObtainPairView.as_view(), name="token_gametoken"),
-    path("signin", UserSigninApiView.as_view()),
+    path("login", LoginView.as_view()),
+    path("logout", LogoutView.as_view()),
     path("signup", UserSignupApiView.as_view()),
     path("", UserListAPIView.as_view()),
     path("<user_id>", UserListDetailAPIView.as_view()),

--- a/user/views.py
+++ b/user/views.py
@@ -1,11 +1,12 @@
 from django.contrib.auth import authenticate, login, logout
 from rest_framework import status
-from rest_framework.permissions import AllowAny, IsAdminUser
+from rest_framework.generics import GenericAPIView
+from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.views import TokenObtainPairView
 
-from user.jwt_claim_serializer import GameTokenObtainPairSerializer
+from user.jwt_claim_serializer import GameTokenObtainPairSerializer, RefreshTokenSerializer
 from user.models import User as UserModel
 from user.serializers import UserListDetailSerializer, UserListSerializer, UserSigninSerializer, UserSignupSerializer
 
@@ -15,7 +16,7 @@ class UserSignupApiView(APIView):
     """
     Assignee : 훈희
 
-    회원가입 view 입니다.
+    post : 회원가입
     회원가입시 입력 data 타입 json 구조는 밑과 같습니다.
     {
         "nickname" : "test1",
@@ -35,22 +36,26 @@ class UserSignupApiView(APIView):
             return Response({"messages": "가입 실패"}, status=status.HTTP_400_BAD_REQUEST)
 
 
-# /users/signin
-class UserSigninApiView(APIView):
+# /users/login
+class LoginView(APIView):
     """
     Assignee : 훈희
 
-    로그인과 회원 전체 조회, 회원 단건 조회 기능입니다.
+    post : 로그인
+    로그인 할때 access token과 refresh token을 함께 가져옴
     로그인시 입력 data 타입 json 구조는 밑과 같습니다.
     {
         "nickname" : "test1",
         "password" : "root1234"
     }
 
+    delete : 로그아웃
+    테스트등 개발 환경에서 사용하기 위한 간단한 로그아웃 기능
+    토큰을 반납하지 않고 로그아웃이 됩니다.
+
     """
 
     permission_classes = [AllowAny]
-    user_serializer = UserSigninSerializer
 
     def post(self, request):
         nickname = request.data.get("nickname", "")
@@ -60,55 +65,87 @@ class UserSigninApiView(APIView):
         if not user:
             return Response({"error": "존재하지 않는 계정이거나 패스워드가 일치하지 않습니다."}, status=status.HTTP_401_UNAUTHORIZED)
 
+        user_serializer = UserSigninSerializer(user)
+        token = GameTokenObtainPairSerializer.get_token(user)
+        refresh_token = str(token)
+        access_token = str(token.access_token)
+        response = Response(
+            {
+                "user": user_serializer.data,
+                "message": "로그인 성공!!",
+                "token": {
+                    "access": access_token,
+                    "refresh": refresh_token,
+                },
+            },
+            status=status.HTTP_200_OK,
+        )
         login(request, user)
-        return Response({"message": "로그인 성공!!"}, status=status.HTTP_200_OK)
+        return response
 
     def delete(self, request):
         user = request.user
         logout(request)
-        return Response(f"로그아웃 되었습니다.{user}님 안녕히가세요!")
+        return Response(f"토큰을 유지하고 로그아웃 되었습니다.{user}님 안녕히가세요!")
+
+
+# /users/logout
+class LogoutView(GenericAPIView):
+    serializer_class = RefreshTokenSerializer
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args):
+        refresh = self.get_serializer(data=request.data)
+        refresh.is_valid(raise_exception=True)
+        refresh.save()
+
+        user = request.user
+        logout(request)
+
+        return Response(f"토큰을 반납하고 로그아웃 되었습니다.{user}님 안녕히가세요!", status=status.HTTP_204_NO_CONTENT)
 
 
 # /users/
 class UserListAPIView(APIView):
+    """
+    Assignee : 훈희
+
+    get : 회원 전체 조회
+    플레이어 전체 목록이 나옵니다.
+    해당 내용은 admin 유저만 확인 가능합니다.
+
+    """
+
     permission_classes = [IsAdminUser]
     user_serializer = UserListSerializer
 
     def get(self, request):
-        """
-        Assignee : 훈희
-
-        플레이어 전체 목록이 나옵니다.
-        해당 내용은 admin 유저만 확인 가능합니다.
-
-        """
         all_user = UserModel.objects.all().order_by("last_login")
         serializer = UserSigninSerializer(all_user, many=True)
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-# /api/gametoken
+# /users/api/gametoken
 class GameTokenObtainPairView(TokenObtainPairView):
+    """
+    Assignee : 훈희
+
+    커스텀 된 토큰 시리얼라이저 테스트용 View입니다.
+
+    """
+
     serializer_class = GameTokenObtainPairSerializer
 
 
+# /users/<user_id>
 class UserListDetailAPIView(APIView):
     """
     Assignee : 훈희
 
-    permission = 모두 가능
-    Http method = GET
-    GET : 유저 단건 조회
-
-    response
-    {
-        totalScore:number,
-            bossRaidHistory: [
-            { raidRecordId:number, score:number, enterTime:string, endTime:string },
-            //..
-        ]
-    }
+    get : 유저 단건 조회
+    totalScore와 bossRaidHistory가 표시되는 유저 단건 조회 입니다.
+    밑의 response 구조에 맞춘 유저 단건 조회 입니다.
 
     """
 

--- a/user/views.py
+++ b/user/views.py
@@ -92,6 +92,21 @@ class LoginView(APIView):
 
 # /users/logout
 class LogoutView(GenericAPIView):
+    """
+     Assignee : 훈희
+
+     post : 로그아웃
+     로그아웃 하면서 토큰을 같이 반납합니다.
+     기존의 delete method를 사용하지 않으며 post 방식으로 refresh token을
+     보내주게 됩니다.
+
+     로그인시 입력 data 타입 json 구조는 밑과 같습니다.
+    {
+       "refresh": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTY1NzkwMzY5MywiaWF0IjoxNjU3ODE3MjkzLCJqdGkiOiJkMjdiMGUxNDU1NTc0NWRjYWRiOTU4YzA1YjA4ZGEzNiIsInVzZXJfaWQiOjgsImlkIjo4LCJuaWNrbmFtZSI6InRlc3Q0MiJ9.iqLPbGoFxaFbp0yXvsKjBwgT7EF29I6URi7O05j2YVg"
+    }
+
+    """
+
     serializer_class = RefreshTokenSerializer
     permission_classes = [IsAuthenticated]
 


### PR DESCRIPTION
### Types of changes

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [x] 리팩토링

### Summary

- 로그아웃 기능 리팩토링 - 토큰 같이 반납할 수 있게 변경
- 토큰 반납위한 시리얼라이저 추가 RefreshTokenSerializer
- 기존 signin -> login으로 변경 logout을 별도 url로 설정  users/logout
- 로그아웃시 토큰도 같이 반납한 API 추가 : refresh token을 같이 보내줘야함

### Changes

- 기존 signin -> login으로 변경 logout을 별도 url로 설정  users/logout


### Screenshots (Optional)
<img width="1597" alt="image" src="https://user-images.githubusercontent.com/89897944/179045863-a314e5d3-b306-4bd1-91f9-9aceeafc943e.png">

