### PR TITLE
Feature/#43

### DIFF
--- a/boss_raid/models.py
+++ b/boss_raid/models.py
@@ -9,7 +9,6 @@ class BossRaid(models.Model):
 
     보스 레이드에 대한 정보를 담고 있는 모델입니다.
     S3데이터를 레디스로 캐싱하는 작업이 이루어지기 전, API 개발에 쓰입니다.
-
     """
 
     id = models.BigAutoField(primary_key=True)

--- a/boss_raid/utils.py
+++ b/boss_raid/utils.py
@@ -7,7 +7,7 @@ import requests
 from django.core.cache import cache
 from django.utils import timezone
 
-from .models import BossRaid, RaidRecord
+from .models import RaidRecord
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 django.setup()
@@ -68,17 +68,12 @@ def get_score_and_end_time(record):
     유저가 플레이 후, 획득 점수와 종료 시간을 구하는 함수입니다.
     """
     raid_record = RaidRecord.objects.get(id=record)
-
     enter_time = raid_record.enter_time
     level = raid_record.level
 
-    """
-    level_clear_score와 time_limit은
-    추후에 Redis에서 데이터를 받아옵니다.
-    """
-    boss_raid = BossRaid.objects.get(level=level)
-    level_clear_score = boss_raid.level_clear_score
-    time_limit = boss_raid.time_limit
+    level_data = get_levels()
+    level_clear_score = level_data[level - 1]["score"]
+    time_limit = get_raid_time()
 
     random_score = random.randint(0, level_clear_score)
 
@@ -100,11 +95,9 @@ def get_playing_records():
     현재 게임을 플레이 하고 있는 레이드 레코드가 있는지 확인하기 위해 필요한 함수 입니다.
     end_time 값이 없는 레코드들을 모두 불러옵니다.
     그중에서 현재 시각을 기준으로 enter_time이 limit_time보다 이전인 아닌 기록들을 return 합니다.
-
-    time_limit은 추후 Redis에서 데이터를 가져오는 코드로 리팩토링 할 예정입니다.
     """
     playing_records = RaidRecord.objects.filter(end_time=None)
     now = timezone.now()
-    time_limit = 180
+    time_limit = get_raid_time()
     playing_record = playing_records.filter(enter_time__gte=now - datetime.timedelta(seconds=time_limit))
     return playing_record

--- a/boss_raid/utils/boss_raid_api_utils.py
+++ b/boss_raid/utils/boss_raid_api_utils.py
@@ -1,63 +1,10 @@
 import datetime
-import os
 import random
 
-import django
-import requests
-from django.core.cache import cache
 from django.utils import timezone
 
-from .models import RaidRecord
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
-django.setup()
-
-
-"""
-Assignee : 정석
-
-redis를 이용한 보스레이드 정보 캐싱 로직입니다.
-보스레이드의 시간만 리턴해주는 get_raid_time
-보스레이드들을 리턴해주는 get_levels 로 구성되어있습니다.
-
-캐싱된 데이터를 필요로하는 이후 로직에서는 2개의 get함수만 사용하게되며,
-캐싱데이터가 없을시엔 자체적으로 get 함수 내에서 create함수를 호출해 캐싱데이터를 생성 후 리턴해줍니다.
-"""
-
-
-def initial_data():
-    url = "https://dmpilf5svl7rv.cloudfront.net/assignment/backend/bossRaidData.json"
-    request = requests.get(url)
-    data = request.json()
-    return data
-
-
-def create_raid_time():
-    data = initial_data()
-    bossraidlimitseconds = data["bossRaids"][0]["bossRaidLimitSeconds"]
-    time = cache.set("limit_time", bossraidlimitseconds, 3600)
-    return time
-
-
-def create_levels():
-    data = initial_data()
-    levels = data["bossRaids"][0]["levels"]
-    levels = cache.set("levels", levels, 3600)
-    return levels
-
-
-def get_raid_time():
-    time = cache.get("limit_time")
-    if time is None:
-        time = create_raid_time()
-    return time
-
-
-def get_levels():
-    levels = cache.get("levels")
-    if levels is None:
-        levels = create_levels()
-    return levels
+from ..models import RaidRecord
+from .redis_cache import get_levels, get_raid_time
 
 
 def get_score_and_end_time(record):

--- a/boss_raid/utils/redis_cache.py
+++ b/boss_raid/utils/redis_cache.py
@@ -1,0 +1,57 @@
+import os
+
+import django
+import requests
+from django.core.cache import cache
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+
+"""
+Assignee : 정석
+
+redis를 이용한 보스레이드 정보 캐싱 로직입니다.
+보스레이드의 시간만 리턴해주는 get_raid_time
+보스레이드들을 리턴해주는 get_levels 로 구성되어있습니다.
+
+캐싱된 데이터를 필요로하는 이후 로직에서는 2개의 get함수만 사용하게되며,
+캐싱데이터가 없을시엔 자체적으로 get 함수 내에서 create함수를 호출해 캐싱데이터를 생성 후 리턴해줍니다.
+"""
+
+
+def initial_data():
+    url = "https://dmpilf5svl7rv.cloudfront.net/assignment/backend/bossRaidData.json"
+    request = requests.get(url)
+    data = request.json()
+    return data
+
+
+def create_raid_time():
+    data = initial_data()
+    bossraidlimitseconds = data["bossRaids"][0]["bossRaidLimitSeconds"]
+    cache.set("limit_time", bossraidlimitseconds, 3600)
+    time = cache.get("limit_time")
+    return time
+
+
+def create_levels():
+    data = initial_data()
+    levels = data["bossRaids"][0]["levels"]
+    cache.set("levels", levels, 3600)
+    levels = cache.get("levels")
+    return levels
+
+
+def get_raid_time():
+    time = cache.get("limit_time")
+    if time is None:
+        time = create_raid_time()
+    return time
+
+
+def get_levels():
+    levels = cache.get("levels")
+    if levels is None:
+        levels = create_levels()
+    return levels

--- a/boss_raid/utils/redis_queue.py
+++ b/boss_raid/utils/redis_queue.py
@@ -1,0 +1,35 @@
+import redis
+
+
+class RedisQueue(object):
+    """
+    Assignee : 민지
+
+    Redis로 구현한 Queue 입니다.
+    """
+
+    def __init__(self, name, **redis_kwargs):
+        self.key = name
+        self.rq = redis.Redis(**redis_kwargs)
+
+    def size(self):
+        return self.rq.llen(self.key)
+
+    def isEmpty(self):
+        return self.size() == 0
+
+    def put(self, element):
+        """왼쪽으로 push 합니다."""
+        self.rq.lpush(self.key, element)
+
+    def get(self, isBlocking=False, timeout=None):
+        if isBlocking:
+            """큐에 요소가 없을때, pop을 막습니다."""
+            element = self.rq.brpop(self.key, timeout=timeout)
+            element = element[1]
+        else:
+            element = self.rq.rpop(self.key)
+        return element
+
+    def set_empty(self):
+        self.rq.flushall()


### PR DESCRIPTION
### Types of changes

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [x] 리팩토링

### Summary

- BossRaid 모델에서 가져오던 데이터를 Redis의 캐시에서 가져옵니다.
- BossRaidEnterAPIView의 동시성 이슈를 해결하기 위해 Redis로 구현한 queue를 이용합니다.

### Changes

- 바뀐 부분


### 특이사항 (Optional)

- boss_raid/views.py 상단에서 RedisQueue 인스턴스를 생성할 때, host가 현재는 localhost 입니다. 배포용 서버에서는 host를 변경해 주어야 합니다.

### Screenshots (Optional)
